### PR TITLE
【イメージ確認依頼】商品選択メニューの追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,10 @@ gem 'jbuilder', '~> 2.0'
 # bundle exec rake doc:rails generates the API under doc/api.
 gem 'sdoc', '~> 0.4.0', group: :doc
 
+# Bootstrap(SASS)用
+gem 'bootstrap-sass'
+
+
 # Use ActiveModel has_secure_password
 # gem 'bcrypt', '~> 3.1.7'
 
@@ -48,8 +52,8 @@ group :development do
 gem 'rails_12factor', group: :production
 ruby '2.2.5'
 
-source 'https://rubygems.org'
-gem 'sinatra'
+
+
 
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,8 +38,13 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.4.0)
     arel (6.0.3)
+    autoprefixer-rails (6.5.0.2)
+      execjs
     binding_of_caller (0.7.2)
       debug_inspector (>= 0.0.1)
+    bootstrap-sass (3.3.7)
+      autoprefixer-rails (>= 5.2.1)
+      sass (>= 3.3.4)
     buftok (0.2.0)
     builder (3.2.2)
     byebug (9.0.6)
@@ -100,8 +105,6 @@ GEM
     pg (0.19.0)
     pkg-config (1.1.7)
     rack (1.6.4)
-    rack-protection (1.5.3)
-      rack
     rack-test (0.6.3)
       rack (>= 1.0)
     rails (4.2.6)
@@ -148,10 +151,6 @@ GEM
       json (~> 1.7, >= 1.7.7)
       rdoc (~> 4.0)
     simple_oauth (0.3.1)
-    sinatra (1.4.7)
-      rack (~> 1.5)
-      rack-protection (~> 1.4)
-      tilt (>= 1.3, < 3)
     spring (1.7.2)
     sprockets (3.7.0)
       concurrent-ruby (~> 1.0)
@@ -197,6 +196,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  bootstrap-sass
   byebug
   coffee-rails (~> 4.1.0)
   jbuilder (~> 2.0)
@@ -206,7 +206,6 @@ DEPENDENCIES
   rails_12factor
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)
-  sinatra
   spring
   therubyracer
   turbolinks

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -13,4 +13,5 @@
 //= require jquery
 //= require jquery_ujs
 //= require turbolinks
+//= require bootstrap-sprockets
 //= require_tree .

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -13,3 +13,5 @@
  *= require_tree .
  *= require_self
  */
+@import "bootstrap-sprockets";
+@import "bootstrap";

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -15,3 +15,11 @@
  */
 @import "bootstrap-sprockets";
 @import "bootstrap";
+/* gridで高さが揃わない場合に調整するclass */
+.row-eq-height{
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  flex-wrap: wrap;
+}

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -12,17 +12,26 @@
         }
     img{
       vertical-align: middle;
-
+      width: 100%;  
     }
-
-    .product{
-       width: 295px;
+    .grid_black{
+     padding:0 15px;
+     border-color: black;
+     border-style: solid;
+     border-width: 1px;
+    }
+    .grid_black_mid{
+     padding:0 15px;
+     border-color:black;
+     border-style:solid;
+     border-width: 1px 0px 1px 0px;
+    }
+    .product{ 
        height: 400px;
        margin: 0 auto;
     }
 
     .p_img{
-       width: 290px;
        height: 250px;
        vertical-align: middle;
        line-height: 250px;
@@ -44,7 +53,7 @@
 <h2 style="text-align: center;">コンビニ3社の商品を比較するよ</h2>
 
 <div class="container">
-<div class="row">
+<div class="row row-eq-height">
 <div class="col-xs-12 col-md-2">
  <div class="dropdown">
     <!-- デフォルト表示部分 -->
@@ -75,8 +84,8 @@
        </ul>
       </div> 
   </div>
-<div class="col-xs-12 col-md-10">
-  <div class="col-xs-9 col-md-3">  
+<div class="col-xs-12 col-md-9 row-eq-height">
+<div class="col-xs-12 col-md-4 grid_black">  
 <h3>ファミマ</h3>
         <div class="product">
           <div class="p_img"><%= image_tag 'R_2230023.jpg' %></div>
@@ -95,7 +104,7 @@
         </div>
 </div>
 
-  <div class="col-xs-9 col-md-3">
+  <div class="col-xs-12 col-md-4 grid_black_mid">
 <h3>セブン</h3>
 
         <div class="product">
@@ -114,7 +123,7 @@
           <% end %>
         </div>
  </div> 
-  <div class="col-xs-9 col-md-3">
+  <div class="col-xs-12 col-md-4 grid_black">
 <h3>ローソン</h3>
 
 

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -43,8 +43,9 @@
 <h1 style="text-align: center; font: fantasy; font-size: 64px;">twentyfour-seven</h1>
 <h2 style="text-align: center;">コンビニ3社の商品を比較するよ</h2>
 
-<div style=" width:1030px; margin: 0 auto;">
-  <div style="width: 100px; height: 500px; float: left; border: 1px solid gray">
+<div class="container">
+<div class="row">
+<div class="col-xs-12 col-md-3">
  <div class="dropdown">
     <!-- デフォルト表示部分 -->
     <a class="btn btn-default dropdown-toggle" id="sample-menu-2" data-toggle="dropdown">
@@ -57,15 +58,25 @@
           <li role="presentation"><a role="menuitem" tabindex="-1" href="#">サラダチキン</a></li>
           <li role="presentation" class="divider"></li>
           <li role="presentation" class="dropdown-header">サラダ</li>
-          <li role="presentation"><a role="menuitem" tabindex="-1" href="#">Separated link</a></li>
+          <li role="presentation"><a role="menuitem" tabindex="-1" href="#">サラダA</a></li>
           <li role="presentation" class="divider"></li>
-          <li class="disabled" role="presentation"><a role="menuitem" tabindex="-1" href="#">Separated link</a></li>
-          <li class="disabled" role="presentation"><a role="menuitem" tabindex="-1" href="#">Separated link</a></li>
-        </ul>
-        <!-- リストここまで -->
-
+          <li role="presentation" class="dropdown-header">スープ</li> 
+          <li role="presentation"><a role="menuitem" tabindex="-1" href="#">スープA</a></li> 
+          <li role="presentation" class="divider"></li>
+          <li role="presentation" class="dropdown-header">おにぎり</li> 
+          <li role="presentation"><a role="menuitem" tabindex="-1" href="#">おにぎりA</a></li>
+          <li role="presentation" class="divider"></li>
+          <li role="presentation" class="dropdown-header">パン</li> 
+          <li role="presentation"><a role="menuitem" tabindex="-1" href="#">パンA</a></li>
+          <li role="presentation" class="divider"></li>
+          <li role="presentation" class="dropdown-header">おでん</li> 
+          <li role="presentation"><a role="menuitem" tabindex="-1" href="#">おでんA</a></li>
+          <li role="presentation" class="divider"></li>
+       </ul>
       </div> 
   </div>
+</div>
+<div class="col-xs-12 clol-md-9">
   <table>
     <tr><th>ファミマ</th><th>セブン</th><th>ローソン</th></tr>
     <tr>
@@ -127,7 +138,7 @@
       </td>
     </tr>
   </table>
-
+</div>
 </div>
 
 <div>

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -45,8 +45,26 @@
 
 <div style=" width:1030px; margin: 0 auto;">
   <div style="width: 100px; height: 500px; float: left; border: 1px solid gray">
-  
-    検索用
+ <div class="dropdown">
+    <!-- デフォルト表示部分 -->
+    <a class="btn btn-default dropdown-toggle" id="sample-menu-2" data-toggle="dropdown">
+          商品選択メニュー<span class="caret"></span>
+        </a>
+        
+        <!-- リスト部分 -->
+        <ul class="dropdown-menu" role="menu" aria-labelledby="sample-menu-2">
+          <li role="presentation" class="dropdown-header">チキン</li> 
+          <li role="presentation"><a role="menuitem" tabindex="-1" href="#">サラダチキン</a></li>
+          <li role="presentation" class="divider"></li>
+          <li role="presentation" class="dropdown-header">サラダ</li>
+          <li role="presentation"><a role="menuitem" tabindex="-1" href="#">Separated link</a></li>
+          <li role="presentation" class="divider"></li>
+          <li class="disabled" role="presentation"><a role="menuitem" tabindex="-1" href="#">Separated link</a></li>
+          <li class="disabled" role="presentation"><a role="menuitem" tabindex="-1" href="#">Separated link</a></li>
+        </ul>
+        <!-- リストここまで -->
+
+      </div> 
   </div>
   <table>
     <tr><th>ファミマ</th><th>セブン</th><th>ローソン</th></tr>

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -45,7 +45,7 @@
 
 <div class="container">
 <div class="row">
-<div class="col-xs-12 col-md-3">
+<div class="col-xs-12 col-md-2">
  <div class="dropdown">
     <!-- デフォルト表示部分 -->
     <a class="btn btn-default dropdown-toggle" id="sample-menu-2" data-toggle="dropdown">
@@ -75,38 +75,16 @@
        </ul>
       </div> 
   </div>
-</div>
-<div class="col-xs-12 clol-md-9">
-  <table>
-    <tr><th>ファミマ</th><th>セブン</th><th>ローソン</th></tr>
-    <tr>
-      <td>
+<div class="col-xs-12 col-md-10">
+  <div class="col-xs-9 col-md-3">  
+<h3>ファミマ</h3>
         <div class="product">
           <div class="p_img"><%= image_tag 'R_2230023.jpg' %></div>
           <p class="p_name">国産鶏のサラダチキン</p>
           <p class="p_attr">税込258円</p>
           <p class="p_attr">113Kcal</p>
         </div>
-      </td>
-      <td>
-        <div class="product">
-          <div class="p_img"><%= image_tag 'R_44326.jpg' %></div>
-          <p class="p_name">サラダチキン</p>
-          <p class="p_attr">税込213円</p>
-          <p class="p_attr">115Kcal</p>
-        </div>
-      </td>
-      <td>
-        <div class="product">
-          <div class="p_img"><%= image_tag 'R_440473_pc.jpg' %></div>
-          <p class="p_name">サラダチキン</p>
-          <p class="p_attr">税込210円</p>
-          <p class="p_attr">125Kcal</p>
-        </div>
-      </td>
-    </tr>
-    <tr>
-      <td>
+
         <div class="tweets">
           <% @result_tweets1.take(3).each do |tw| %> 
             <p class="tw">
@@ -115,8 +93,18 @@
             </p>
           <% end %>
         </div>
-      </td>
-      <td>
+</div>
+
+  <div class="col-xs-9 col-md-3">
+<h3>セブン</h3>
+
+        <div class="product">
+          <div class="p_img"><%= image_tag 'R_44326.jpg' %></div>
+          <p class="p_name">サラダチキン</p>
+          <p class="p_attr">税込213円</p>
+          <p class="p_attr">115Kcal</p>
+        </div>
+
         <div class="tweets">
           <% @result_tweets2.take(3).each do |tw| %> 
             <p class="tw">
@@ -125,8 +113,19 @@
             </p>
           <% end %>
         </div>
-      </td>
-      <td>
+ </div> 
+  <div class="col-xs-9 col-md-3">
+<h3>ローソン</h3>
+
+
+
+        <div class="product">
+          <div class="p_img"><%= image_tag 'R_440473_pc.jpg' %></div>
+          <p class="p_name">サラダチキン</p>
+          <p class="p_attr">税込210円</p>
+          <p class="p_attr">125Kcal</p>
+        </div>
+
         <div class="tweets">
           <% @result_tweets3.take(3).each do |tw| %> 
             <p class="tw">
@@ -135,9 +134,7 @@
             </p>
           <% end %>
         </div>
-      </td>
-    </tr>
-  </table>
+</div>
 </div>
 </div>
 


### PR DESCRIPTION
#28 
bootstrapの導入と合わせてテーブルレイアウトをgridに移行してます。

追加商品が不明で、メニューイメージが不明でしたのでイメージで一度組みました。
![default](https://cloud.githubusercontent.com/assets/3953851/19221715/9094122e-8e83-11e6-8d23-d8a322b770cc.jpg)

以下レビュー時に確認お願いします
・商品分類、商品の階層構造としているがこれで合っているのか
・初期表示の際にデフォルトが設定されていなくて良いのか
・設定されている場合は条件（サラダキチン固定？ランダム？）
・設定されていない場合は、全部の商品を表示させておくのか
