### PR TITLE
【確認依頼等】メニューから選択

### DIFF
--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -5,6 +5,9 @@ class WelcomeController < ApplicationController
     @result_tweets1 = search_tweets("サラダチキン　ファミマ　おいしい") 
     @result_tweets2 = search_tweets("サラダチキン　セブンイレブン　おいしい") 
     @result_tweets3 = search_tweets("サラダチキン　ローソン　おいしい") 
+    
+    @product = (self.get_product_hash)["サラダキチン"]
+
   end
 
   def search_tweets(query)
@@ -21,5 +24,15 @@ class WelcomeController < ApplicationController
     return client.search(query, count: 3, result_type: "recent", exclude: "retweets", since_id: since_id)
     
   end
+  
+  def get_product_hash
+    # 品目 => コンビニ => 商品
+    hash = Hash.new { |h,k| h[k] = {} }
+    hash["サラダキチン"]["ファミマ"]= Product_dto.new("ファミマ","キチン","サラダキチン","国産鶏のサラダチキン",258,113,"R_2230023.jpg")
+    hash["サラダキチン"]["セブン"]= Product_dto.new("セブン","キチン","サラダキチン","サラダチキン",213,115,"R_44326.jpg")
+    hash["サラダキチン"]["ローソン"]= Product_dto.new("ローソン","キチン","サラダキチン","サラダチキン",210,125,"R_440473_pc.jpg")
 
+    return hash
+　end
+end
 end

--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -1,14 +1,19 @@
 class WelcomeController < ApplicationController
 
   def index
-    # TODO: 検索ワードの規則性に応じてパラメタ化する
-    @result_tweets1 = search_tweets("サラダチキン　ファミマ　おいしい") 
-    @result_tweets2 = search_tweets("サラダチキン　セブンイレブン　おいしい") 
-    @result_tweets3 = search_tweets("サラダチキン　ローソン　おいしい") 
+    item = params[:item]
+    if(item.nil? || item == "") 
+      item = "サラダキチン"
+    end
+    # TODO: 検索ワードの規則性に応じてパラメタ化する    
+    @result_tweets1 = search_tweets(item + "　ファミマ　おいしい") 
+    @result_tweets2 = search_tweets(item + "　セブンイレブン　おいしい") 
+    @result_tweets3 = search_tweets(item + "　ローソン　おいしい") 
     
-    @product = (self.get_product_hash)["サラダキチン"]
+    @product = (self.get_product_hash)[item]
 
   end
+  
 
   def search_tweets(query)
     # APIの各種Keyの設定
@@ -31,7 +36,12 @@ class WelcomeController < ApplicationController
     hash["サラダキチン"]["ファミマ"]= Product_dto.new("ファミマ","キチン","サラダキチン","国産鶏のサラダチキン",258,113,"R_2230023.jpg")
     hash["サラダキチン"]["セブン"]= Product_dto.new("セブン","キチン","サラダキチン","サラダチキン",213,115,"R_44326.jpg")
     hash["サラダキチン"]["ローソン"]= Product_dto.new("ローソン","キチン","サラダキチン","サラダチキン",210,125,"R_440473_pc.jpg")
-
+    hash["サラダ"]["ファミマ"]= Product_dto.new("ファミマ","サラダ","サラダ","フレッシュ野菜サラダ(ドレッシング別売り）",163,30,nil)
+    hash["サラダ"]["セブン"]= Product_dto.new("セブン","サラダ","サラダ","ミックス野菜サラダ(ドレッシング別売り）",163,"-",nil)
+    hash["サラダ"]["ローソン"]= Product_dto.new("ローソン","サラダ","サラダ","コーンサラダ(ドレッシング別売り）",148,49,nil) 
+    hash["スープ"]["ファミマ"]= Product_dto.new("ファミマ","スープ","スープ","豚汁",298,106,nil)
+    hash["スープ"]["セブン"]= Product_dto.new("セブン","スープ","スープ","生姜香る鶏肉と野菜の和風スープ",298,141,nil)
+    hash["スープ"]["ローソン"]= Product_dto.new("ローソン","スープ","スープ","Lクラムチャウダー",298,141,nil)
     return hash
 　end
 end

--- a/app/models/product_dto.rb
+++ b/app/models/product_dto.rb
@@ -1,0 +1,16 @@
+class Product_dto 
+  include ActiveModel::Model
+  
+  attr_accessor :shop,:category,:item,:name,:price,:calorie,:image_url,:twitter
+  
+  def initialize(shop,category,item,name,price,calorie,image_url)
+    @shop=shop
+    @category=category
+    @item=item
+    @name=name
+    @price=price
+    @calorie=calorie
+    @image_url=image_url
+  end
+  
+end

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -88,10 +88,10 @@
 <div class="col-xs-12 col-md-4 grid_black">  
 <h3>ファミマ</h3>
         <div class="product">
-          <div class="p_img"><%= image_tag 'R_2230023.jpg' %></div>
-          <p class="p_name">国産鶏のサラダチキン</p>
-          <p class="p_attr">税込258円</p>
-          <p class="p_attr">113Kcal</p>
+          <div class="p_img"><%= image_tag @product["ファミマ"].image_url %></div>
+          <p class="p_name"><%= @product["ファミマ"].name %></p>
+          <p class="p_attr">税込<%= @product["ファミマ"].price %>円</p>
+          <p class="p_attr"><%= @product["ファミマ"].calorie %>kcal</p>
         </div>
 
         <div class="tweets">
@@ -108,10 +108,13 @@
 <h3>セブン</h3>
 
         <div class="product">
-          <div class="p_img"><%= image_tag 'R_44326.jpg' %></div>
-          <p class="p_name">サラダチキン</p>
-          <p class="p_attr">税込213円</p>
-          <p class="p_attr">115Kcal</p>
+          <div class="p_img"><%= image_tag @product["セブン"].image_url %></div>
+            
+          <p class="p_name"><%= @product["セブン"].name %></p>
+          <p class="p_attr">税込<%= @product["セブン"].price %>円</p>
+          <p class="p_attr"><%= @product["セブン"].calorie %>kcal</p>
+       
+      
         </div>
 
         <div class="tweets">
@@ -125,14 +128,13 @@
  </div> 
   <div class="col-xs-12 col-md-4 grid_black">
 <h3>ローソン</h3>
-
-
-
         <div class="product">
-          <div class="p_img"><%= image_tag 'R_440473_pc.jpg' %></div>
-          <p class="p_name">サラダチキン</p>
-          <p class="p_attr">税込210円</p>
-          <p class="p_attr">125Kcal</p>
+          <div class="p_img"><%= image_tag @product["ローソン"].image_url %></div>  
+          <p class="p_name"><%= @product["ローソン"].name %></p>
+          <p class="p_attr">税込<%= @product["ローソン"].price %>円</p>
+          <p class="p_attr"><%= @product["ローソン"].calorie %>kcal</p>
+        
+       
         </div>
 
         <div class="tweets">

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -27,7 +27,7 @@
      border-width: 1px 0px 1px 0px;
     }
     .product{ 
-       height: 400px;
+
        margin: 0 auto;
     }
 
@@ -64,13 +64,13 @@
         <!-- リスト部分 -->
         <ul class="dropdown-menu" role="menu" aria-labelledby="sample-menu-2">
           <li role="presentation" class="dropdown-header">チキン</li> 
-          <li role="presentation"><a role="menuitem" tabindex="-1" href="#">サラダチキン</a></li>
+          <li role="presentation"><a role="menuitem" tabindex="-1" href="/show/サラダキチン">サラダチキン</a></li>
           <li role="presentation" class="divider"></li>
           <li role="presentation" class="dropdown-header">サラダ</li>
-          <li role="presentation"><a role="menuitem" tabindex="-1" href="#">サラダA</a></li>
+          <li role="presentation"><a role="menuitem" tabindex="-1" href="/show/サラダ">サラダ</a></li>
           <li role="presentation" class="divider"></li>
           <li role="presentation" class="dropdown-header">スープ</li> 
-          <li role="presentation"><a role="menuitem" tabindex="-1" href="#">スープA</a></li> 
+          <li role="presentation"><a role="menuitem" tabindex="-1" href="/show/スープ">スープ</a></li> 
           <li role="presentation" class="divider"></li>
           <li role="presentation" class="dropdown-header">おにぎり</li> 
           <li role="presentation"><a role="menuitem" tabindex="-1" href="#">おにぎりA</a></li>
@@ -88,7 +88,9 @@
 <div class="col-xs-12 col-md-4 grid_black">  
 <h3>ファミマ</h3>
         <div class="product">
+          <% if !@product["ファミマ"].image_url.nil? %> 
           <div class="p_img"><%= image_tag @product["ファミマ"].image_url %></div>
+          <% end %>
           <p class="p_name"><%= @product["ファミマ"].name %></p>
           <p class="p_attr">税込<%= @product["ファミマ"].price %>円</p>
           <p class="p_attr"><%= @product["ファミマ"].calorie %>kcal</p>
@@ -108,8 +110,9 @@
 <h3>セブン</h3>
 
         <div class="product">
+          <% if !@product["セブン"].image_url.nil? %> 
           <div class="p_img"><%= image_tag @product["セブン"].image_url %></div>
-            
+          <% end %>
           <p class="p_name"><%= @product["セブン"].name %></p>
           <p class="p_attr">税込<%= @product["セブン"].price %>円</p>
           <p class="p_attr"><%= @product["セブン"].calorie %>kcal</p>
@@ -129,7 +132,9 @@
   <div class="col-xs-12 col-md-4 grid_black">
 <h3>ローソン</h3>
         <div class="product">
+          <% if !@product["ローソン"].image_url.nil? %> 
           <div class="p_img"><%= image_tag @product["ローソン"].image_url %></div>  
+          <% end %>
           <p class="p_name"><%= @product["ローソン"].name %></p>
           <p class="p_attr">税込<%= @product["ローソン"].price %>円</p>
           <p class="p_attr"><%= @product["ローソン"].calorie %>kcal</p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
 
   # You can have the root of your site routed with "root"
    root 'welcome#index'
-
+   get 'show/:item' => 'welcome#index'
   # Example of regular route:
   #   get 'products/:id' => 'catalog#view'
 


### PR DESCRIPTION
#29 
show/[商品名]でアクセス出来るようにしました
・サラダキチン
・サラダ
・スープ

作業状況共有がてらプルリクとして共有しておきます。

【既知の問題】
・おにぎりとパンへの対応がまだ出来てないです。
・サラダキチンのTwitter取得が動かなくなりました @HirokiTakenaka さん分かります？ 
・単体テストがかけてないです
・写真がないケースに対応したところ、商品名が２行にまたがる場合にレイアウトが乱れるようになってます
・スープが別々の商品過ぎて比較に見えない
 （・URLパラメータで商品名使ってるのは正しくない。商品IDとの対応表があるのが本来の姿）