### PR TITLE
#43 誤ってmergeしてしまった為プルリクしなおし

### DIFF
--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -36,6 +36,7 @@ class WelcomeController < ApplicationController
 
     return result_tweets.count    
 
+
   end
   
   def get_product_hash

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -104,12 +104,13 @@
           <p class="p_attr">税込<%= @product["ファミマ"].price %>円</p>
           <p class="p_attr"><%= @product["ファミマ"].calorie %>kcal</p>
         </div>
-
+        <%= cache @product["ファミマ"].name ,expires_in:1.hours,skip_digest:true do %> 
         <div class="tweets">
           <p class="tw_all">話題数：<%= @tw_cnt_all1  %><br></p>
           <p class="tw_good">　おいしい：<%= @tw_cnt_good1  %><br></p>
           <p class="tw_bad">　まずい：<%= @tw_cnt_bad1  %><br></p>
         </div>
+        <% end %>
 </div>
 
   <div class="col-xs-12 col-md-4 grid_black_mid shadow_seven">
@@ -126,11 +127,13 @@
       
         </div>
 
+        <%= cache @product["セブン"].name ,expires_in:1.hours,skip_digest:true do %> 
         <div class="tweets">
           <p class="tw_all">話題数：<%= @tw_cnt_all2  %><br></p>
           <p class="tw_good">　おいしい：<%= @tw_cnt_good2  %><br></p>
           <p class="tw_bad">　まずい：<%= @tw_cnt_bad2  %><br></p>
         </div>
+        <% end %>
  </div> 
   <div class="col-xs-12 col-md-4 grid_black shadow_lawson">
 <h3>ローソン</h3>
@@ -145,11 +148,13 @@
        
         </div>
 
+        <%= cache @product["ローソン"].name ,expires_in:1.hours,skip_digest:true do %> 
         <div class="tweets">
           <p class="tw_all">話題数：<%= @tw_cnt_all3  %><br></p>
           <p class="tw_good">　おいしい：<%= @tw_cnt_good3  %><br></p>
           <p class="tw_bad">　まずい：<%= @tw_cnt_bad3  %><br></p>
         </div>
+        <% end %>
 </div>
 </div>
 <% end %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -11,7 +11,7 @@ Rails.application.configure do
 
   # Show full error reports and disable caching.
   config.consider_all_requests_local       = true
-  config.action_controller.perform_caching = false
+  config.action_controller.perform_caching = true
 
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false


### PR DESCRIPTION
#43 

誤って直接マージしてしまったので、
空pushしました。

本来の差分については下記コミットを参照ください。
https://github.com/IshidaHIRO/SDD3/commit/49600a9f92a471722ea8faa16981170d63e00c52

見栄えの調整とかソースのリファクタリングとか詰められてないですが、
パフォーマンスが少し気になるため早めにご意見もらいたくプルリクします。

### 変更点
* Tweet内容ではなく、直近１週間の件数を取得するメソッドを追加
* 話題数、おいしい、まずいのそれぞれの件数を表示するよう変更

### 注意点
* 件数取得の処理時間が少しかかります
  * APIの検索結果の件数がそのままは取れず、イテレータで数えている分かかっています
　（get_twitter_cntで検索結果のcountを取っている）
  * 何か改善策あればアドバイスください

### 備考
* 当初100件以上は次ページのロードが必要だと考えててその方法の検討に時間がかかったが、  
イテレータ経由なら全Tweetの件数を数えられることに気づきそれを採用  
（APIで1度の取得で扱えるTweetは最大100件）
* [Twitter gemの検索結果インスタンスとその内部を解説](http://d.hatena.ne.jp/riocampos+tech/20150421/twitter_gem_search_tips)