### PR TITLE
アコーディオン表示を追加

### DIFF
--- a/app/helpers/welcome_helper.rb
+++ b/app/helpers/welcome_helper.rb
@@ -46,37 +46,39 @@ module WelcomeHelper
   end
   
   def print_product(target,val1,val2)
-     content_tag(:div, :class => 'product') do
-       concat content_tag(:p, target.name,:class => 'p_name') 
-       concat (content_tag(:dl ,:class => 'dl-horizontal') do
-          concat content_tag(:dt,"税込価格")
-          concat content_tag(:dd,self.emphasize_least(target.price,val1.price,val2.price) + "円")
-          concat content_tag(:dt,"熱量")
-          concat content_tag(:dd,emphasize_least(target.calorie,val1.calorie,val2.calorie)+"kcal")
-          concat content_tag(:dt,"分量")
-          concat content_tag(:dd,emphasize_most(target.net,val1.net,val2.net)+"g")
-          concat content_tag(:dt,"タンパク質")
-          concat content_tag(:dd,emphasize_most(target.protein,val1.protein,val2.protein)+"g")
-          concat content_tag(:dt,"脂質")
-          concat content_tag(:dd,emphasize_least(target.fat,val1.fat,val2.fat)+"g")
-          concat content_tag(:dt,"炭水化物")
-          concat content_tag(:dd,emphasize_least(target.carbon,val1.carbon,val2.carbon)+"g")
-          concat content_tag(:dt,"糖質")
-          concat content_tag(:dd,emphasize_least(target.sugar,val1.sugar,val2.sugar)+"g")
-          concat content_tag(:dt,"食物繊維")
-          concat content_tag(:dd,emphasize_most(target.fiber,val1.fiber,val2.fiber)+"g")
-          concat content_tag(:dt,"ナトリウム")
-          concat content_tag(:dd,emphasize_least(target.sodium,val1.sodium,val2.sodium)+"mg")
-       end)
-       concat (content_tag(:div,:class=>"tweets") do
-          content_tag(:dl, :class=>"dl-horizontal") do
-            concat content_tag(:dt,"話題数")
-            concat content_tag(:dd,emphasize_most(target.tweets_count_all,val1.tweets_count_all,val2.tweets_count_all))
-            concat content_tag(:dt,"おいしい")
-            concat content_tag(:dd,emphasize_most(target.tweets_count_good,val1.tweets_count_good,val2.tweets_count_bad))
-            concat content_tag(:dt,"まずい")
-            concat content_tag(:dd,emphasize_least(target.tweets_count_bad,val1.tweets_count_bad,val2.tweets_count_bad)) 
-          end
+     content_tag(:div, :class => 'product', :id => 'accordion') do
+       concat content_tag(:a, target.name,:class => 'p_name', :"data-toggle" => 'collapse', :"data-parent" => '#accordion', :href => '#collapseOne')
+       concat (content_tag(:div, :class => 'spec', :id => 'collapseOne') do 
+	 concat (content_tag(:dl ,:class => 'dl-horizontal') do
+	    concat content_tag(:dt,"税込価格")
+	    concat content_tag(:dd,self.emphasize_least(target.price,val1.price,val2.price) + "円")
+	    concat content_tag(:dt,"熱量")
+	    concat content_tag(:dd,emphasize_least(target.calorie,val1.calorie,val2.calorie)+"kcal")
+	    concat content_tag(:dt,"分量")
+	    concat content_tag(:dd,emphasize_most(target.net,val1.net,val2.net)+"g")
+	    concat content_tag(:dt,"タンパク質")
+	    concat content_tag(:dd,emphasize_most(target.protein,val1.protein,val2.protein)+"g")
+	    concat content_tag(:dt,"脂質")
+	    concat content_tag(:dd,emphasize_least(target.fat,val1.fat,val2.fat)+"g")
+	    concat content_tag(:dt,"炭水化物")
+	    concat content_tag(:dd,emphasize_least(target.carbon,val1.carbon,val2.carbon)+"g")
+	    concat content_tag(:dt,"糖質")
+	    concat content_tag(:dd,emphasize_least(target.sugar,val1.sugar,val2.sugar)+"g")
+	    concat content_tag(:dt,"食物繊維")
+	    concat content_tag(:dd,emphasize_most(target.fiber,val1.fiber,val2.fiber)+"g")
+	    concat content_tag(:dt,"ナトリウム")
+	    concat content_tag(:dd,emphasize_least(target.sodium,val1.sodium,val2.sodium)+"mg")
+	 end)
+	 concat (content_tag(:div,:class=>"tweets") do
+	    content_tag(:dl, :class=>"dl-horizontal") do
+	      concat content_tag(:dt,"話題数")
+	      concat content_tag(:dd,emphasize_most(target.tweets_count_all,val1.tweets_count_all,val2.tweets_count_all))
+	      concat content_tag(:dt,"おいしい")
+	      concat content_tag(:dd,emphasize_most(target.tweets_count_good,val1.tweets_count_good,val2.tweets_count_bad))
+	      concat content_tag(:dt,"まずい")
+	      concat content_tag(:dd,emphasize_least(target.tweets_count_bad,val1.tweets_count_bad,val2.tweets_count_bad)) 
+	    end
+	 end)
        end)
      end
    end

--- a/app/helpers/welcome_helper.rb
+++ b/app/helpers/welcome_helper.rb
@@ -46,9 +46,9 @@ module WelcomeHelper
   end
   
   def print_product(target,val1,val2)
-     content_tag(:div, :class => 'product', :id => 'accordion') do
-       concat content_tag(:a, target.name,:class => 'p_name', :"data-toggle" => 'collapse', :"data-parent" => '#accordion', :href => '#collapseOne')
-       concat (content_tag(:div, :class => 'spec', :id => 'collapseOne') do 
+     content_tag(:div, :class => 'product', :id => 'accordion'+target.shop) do
+       concat content_tag(:a, target.name,:class => 'p_name', :"data-toggle" => 'collapse', :"data-parent" => '#accordion'+target.shop, :href => '#collapseOne'+target.shop)
+       concat (content_tag(:div, :class => 'spec', :id => 'collapseOne'+target.shop) do 
 	 concat (content_tag(:dl ,:class => 'dl-horizontal') do
 	    concat content_tag(:dt,"税込価格")
 	    concat content_tag(:dd,self.emphasize_least(target.price,val1.price,val2.price) + "円")

--- a/test/controllers/welcome_controller_test.rb
+++ b/test/controllers/welcome_controller_test.rb
@@ -17,90 +17,90 @@ class WelcomeControllerTest < ActionController::TestCase
     init("サラダキチン")
     get :index
     assert_response :success
-    assert_select "div.shadow_famima div.product p.p_name" ,"国産鶏のサラダチキン"
-    assert_select "div.shadow_seven div.product p.p_name" ,"サラダチキン"
-    assert_select "div.shadow_lawson div.product p.p_name" ,"サラダチキン"
+    assert_select "div.shadow_famima div.product a.p_name" ,"国産鶏のサラダチキン"
+    assert_select "div.shadow_seven div.product a.p_name" ,"サラダチキン"
+    assert_select "div.shadow_lawson div.product a.p_name" ,"サラダチキン"
     assert_select "span.first"
   end
   test "サラダチキンの表示" do
     init("サラダキチン")
     get :index,{"item"=>"サラダチキン"}
     assert_response :success 
-    assert_select "div.shadow_famima div.product p.p_name" ,"国産鶏のサラダチキン"
-    assert_select "div.shadow_seven div.product p.p_name" ,"サラダチキン"
-    assert_select "div.shadow_lawson div.product p.p_name" ,"サラダチキン"
+    assert_select "div.shadow_famima div.product a.p_name" ,"国産鶏のサラダチキン"
+    assert_select "div.shadow_seven div.product a.p_name" ,"サラダチキン"
+    assert_select "div.shadow_lawson div.product a.p_name" ,"サラダチキン"
     assert_select "span.first"
   end 
   test "サラダの表示" do
     init("サラダ")
     get :index,{"item"=>"サラダ"}
     assert_response :success 
-    assert_select "div.shadow_famima div.product p.p_name" ,"フレッシュ野菜サラダ(ドレッシング別売り）"
-    assert_select "div.shadow_seven div.product p.p_name" ,"ミックス野菜サラダ(ドレッシング別売り）"
-    assert_select "div.shadow_lawson div.product p.p_name" ,"コーンサラダ(ドレッシング別売り）"
+    assert_select "div.shadow_famima div.product a.p_name" ,"フレッシュ野菜サラダ(ドレッシング別売り）"
+    assert_select "div.shadow_seven div.product a.p_name" ,"ミックス野菜サラダ(ドレッシング別売り）"
+    assert_select "div.shadow_lawson div.product a.p_name" ,"コーンサラダ(ドレッシング別売り）"
     assert_select "span.first"
   end 
   test "スープの表示" do
     init("スープ")
     get :index,{"item"=>"スープ"}
     assert_response :success 
-    assert_select "div.shadow_famima div.product p.p_name" ,"10種具材の豚汁"
-    assert_select "div.shadow_seven div.product p.p_name" ,"生姜香る鶏肉と野菜の和風スープ"
-    assert_select "div.shadow_lawson div.product p.p_name" ,"Lクラムチャウダー"
+    assert_select "div.shadow_famima div.product a.p_name" ,"10種具材の豚汁"
+    assert_select "div.shadow_seven div.product a.p_name" ,"生姜香る鶏肉と野菜の和風スープ"
+    assert_select "div.shadow_lawson div.product a.p_name" ,"Lクラムチャウダー"
     assert_select "span.first"
   end 
   test "おにぎり（梅）の表示" do
     init("おにぎり（梅）")
     get :index,{"item"=>"おにぎり（梅）"}
     assert_response :success 
-    assert_select "div.shadow_famima div.product p.p_name" ,"紀州南高梅"
-    assert_select "div.shadow_seven div.product p.p_name" ,"紀州南高梅"
-    assert_select "div.shadow_lawson div.product p.p_name" ,"紀州南高梅"
+    assert_select "div.shadow_famima div.product a.p_name" ,"紀州南高梅"
+    assert_select "div.shadow_seven div.product a.p_name" ,"紀州南高梅"
+    assert_select "div.shadow_lawson div.product a.p_name" ,"紀州南高梅"
     assert_select "span.first"
   end 
   test "おにぎり（ツナ）の表示" do
     init("おにぎり（ツナ）")
     get :index,{"item"=>"おにぎり（ツナ）"}
     assert_response :success 
-    assert_select "div.shadow_famima div.product p.p_name" ,"和風ツナマヨネーズ"
-    assert_select "div.shadow_seven div.product p.p_name" ,"ツナマヨネーズ"
-    assert_select "div.shadow_lawson div.product p.p_name" ,"シーチキンマヨネーズ"
+    assert_select "div.shadow_famima div.product a.p_name" ,"和風ツナマヨネーズ"
+    assert_select "div.shadow_seven div.product a.p_name" ,"ツナマヨネーズ"
+    assert_select "div.shadow_lawson div.product a.p_name" ,"シーチキンマヨネーズ"
     assert_select "span.first"
   end 
   test "おにぎり（昆布）の表示" do
     init("おにぎり（昆布）")
     get :index,{"item"=>"おにぎり（昆布）"}
     assert_response :success 
-    assert_select "div.shadow_famima div.product p.p_name" ,"北海道産真昆布"
-    assert_select "div.shadow_seven div.product p.p_name" ,"日高昆布"
-    assert_select "div.shadow_lawson div.product p.p_name" ,"日高昆布"
+    assert_select "div.shadow_famima div.product a.p_name" ,"北海道産真昆布"
+    assert_select "div.shadow_seven div.product a.p_name" ,"日高昆布"
+    assert_select "div.shadow_lawson div.product a.p_name" ,"日高昆布"
     assert_select "span.first"
   end 
   test "おにぎり（納豆巻き）の表示" do
     init("おにぎり（納豆巻き）")
     get :index,{"item"=>"おにぎり（納豆巻き）"}
     assert_response :success 
-    assert_select "div.shadow_famima div.product p.p_name" ,"納豆"
-    assert_select "div.shadow_seven div.product p.p_name" ,"-"
-    assert_select "div.shadow_lawson div.product p.p_name" ,"納豆"
+    assert_select "div.shadow_famima div.product a.p_name" ,"納豆"
+    assert_select "div.shadow_seven div.product a.p_name" ,"-"
+    assert_select "div.shadow_lawson div.product a.p_name" ,"納豆"
     assert_select "span.first"
   end  
   test "パンの表示" do
     init("パン")
     get :index,{"item"=>"パン"}
     assert_response :success 
-    assert_select "div.shadow_famima div.product p.p_name" ,"チョコチップスナック"
-    assert_select "div.shadow_seven div.product p.p_name" ,"チョコチップスナック"
-    assert_select "div.shadow_lawson div.product p.p_name" ,"チョコチップスティックパン"
+    assert_select "div.shadow_famima div.product a.p_name" ,"チョコチップスナック"
+    assert_select "div.shadow_seven div.product a.p_name" ,"チョコチップスナック"
+    assert_select "div.shadow_lawson div.product a.p_name" ,"チョコチップスティックパン"
     assert_select "span.first"
   end 
   test "飲むヨーグルト（プレーン）の表示" do
     init("飲むヨーグルト（プレーン）")
     get :index,{"item"=>"飲むヨーグルト（プレーン）"}
     assert_response :success 
-    assert_select "div.shadow_famima div.product p.p_name" ,"プレーンヨーグルトドリンク"
-    assert_select "div.shadow_seven div.product p.p_name" ,"生きて腸まで届く乳酸菌入りのむプレーンヨーグルト"
-    assert_select "div.shadow_lawson div.product p.p_name" ,"生きて腸まで届くビフィズス菌ドリンクヨーグルトプレーン"
+    assert_select "div.shadow_famima div.product a.p_name" ,"プレーンヨーグルトドリンク"
+    assert_select "div.shadow_seven div.product a.p_name" ,"生きて腸まで届く乳酸菌入りのむプレーンヨーグルト"
+    assert_select "div.shadow_lawson div.product a.p_name" ,"生きて腸まで届くビフィズス菌ドリンクヨーグルトプレーン"
     assert_select "span.first"
   end 
   test "NotFoundの表示" do 


### PR DESCRIPTION
#60 
アコーディオン表示を追加しましたが、一部気になるところがあります。
[heroku](https://arcane-sea-57466.herokuapp.com/)

### 変更点
* ヘルパーの成分表示メソッド「print_product」にアコーディオン表示を追加
* 上記変更に合わせてテストコードも変更

### 参考
* [Bootstrap3 アコーディオンとCollapseの簡単な使い方](http://designup.jp/bootstrap3-collapse-194/)

### 気になる点
1. PC表示時もアコーディオンが有効になっている
1. 初期状態でアコーディオンが開いた状態（モバイルは閉じているのがデフォルト？）
1. 閉じた状態も価格とカロリーは表示するか