### PR TITLE
【作業中】DBの情報から比較表を表示するの実装

### DIFF
--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -40,9 +40,7 @@ class WelcomeController < ApplicationController
       end
     end
 
-    # TODO: この変数にDBから取得した値をセットしてください
-    # @comparisons = {:user => "ファミマニア", :comparison => "ツヤ", :point1 => "80", :point2 => "30", :point3 => "40"}
-    @comparisons = Comparison.all
+    @comparisons = Comparison.where(item: item)
 
   end
   

--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -40,6 +40,10 @@ class WelcomeController < ApplicationController
       end
     end
 
+    # TODO: この変数にDBから取得した値をセットしてください
+    # @comparisons = {:user => "ファミマニア", :comparison => "ツヤ", :point1 => "80", :point2 => "30", :point3 => "40"}
+    @comparisons = Comparison.all
+
   end
   
   def get_twitter_cnt(query)

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -144,6 +144,7 @@
         </div>
       </div>
 
+<!--
         <div class="col-xs-12 col-md-4 grid_black shadow_famima">
         <div style="margin-top : 10px">
           <dl class="dl-horizontal"><dt>ガッツリ度</dt><dd>60</dd></dl></div>
@@ -164,6 +165,23 @@
                   <dl class="dl-horizontal"><dt>味の濃さ</dt><dd>80</dd></dl>
                   <dl class="dl-horizontal"><dt>ツヤ</dt><dd>70</dd></dl>
         </div>
+-->
+       <!-- TODO: DBから取得出来るようになったら、ハッシュじゃなくてインスタンスのフィールドを読み込むよう変更する -->        
+       <div class="col-xs-12 col-md-4 grid_black shadow_famima">
+         <% @comparisons.each do |cp| %>
+           <dl class="dl-horizontal"><dt><%= cp.comparison %></dt><dd><%= cp.point1 %></dd></dl>
+         <% end %> 
+       </div>
+       <div class="col-xs-12 col-md-4 grid_black_mid shadow_seven">
+         <% @comparisons.each do |cp| %>
+           <dl class="dl-horizontal"><dt><%= cp.comparison %></dt><dd><%= cp.point2 %></dd></dl>
+         <% end %> 
+       </div>
+       <div class="col-xs-12 col-md-4 grid_black shadow_lawson">
+         <% @comparisons.each do |cp| %>
+           <dl class="dl-horizontal"><dt><%= cp.comparison %></dt><dd><%= cp.point3 %></dd></dl>
+         <% end %> 
+       </div>
 
 <!-- オリジナル比較表終了 -->
 

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -144,29 +144,6 @@
         </div>
       </div>
 
-<!--
-        <div class="col-xs-12 col-md-4 grid_black shadow_famima">
-        <div style="margin-top : 10px">
-          <dl class="dl-horizontal"><dt>ガッツリ度</dt><dd>60</dd></dl></div>
-                  <dl class="dl-horizontal"><dt>味の濃さ</dt><dd><font color="red">90</font></dd></dl>
-                  <dl class="dl-horizontal"><dt>ツヤ</dt><dd><font color="red">100</font></dd></dl>
-        </div>
-
-        <div class="col-xs-12 col-md-4 grid_black_mid shadow_seven">
-        <div style="margin-top : 10px">
-          <dl class="dl-horizontal"><dt>ガッツリ度</dt><dd><font color="red">80</font></dd></dl></div>
-                  <dl class="dl-horizontal"><dt>味の濃さ</dt><dd>70</dd></dl>
-                  <dl class="dl-horizontal"><dt>ツヤ</dt><dd>60</dd></dl>
-                </div>
-
-        <div class="col-xs-12 col-md-4 grid_black shadow_lawson">
-        <div style="margin-top : 10px">
-          <dl class="dl-horizontal"><dt>ガッツリ度</dt><dd><font color="red">80</font></dd></dl></div>
-                  <dl class="dl-horizontal"><dt>味の濃さ</dt><dd>80</dd></dl>
-                  <dl class="dl-horizontal"><dt>ツヤ</dt><dd>70</dd></dl>
-        </div>
--->
-       <!-- TODO: DBから取得出来るようになったら、ハッシュじゃなくてインスタンスのフィールドを読み込むよう変更する -->        
        <div class="col-xs-12 col-md-4 grid_black shadow_famima">
          <% @comparisons.each do |cp| %>
            <dl class="dl-horizontal"><dt><%= cp.comparison %></dt><dd><%= cp.point1 %></dd></dl>

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -145,19 +145,25 @@
       </div>
 
        <div class="col-xs-12 col-md-4 grid_black shadow_famima">
-         <% @comparisons.each do |cp| %>
-           <dl class="dl-horizontal"><dt><%= cp.comparison %></dt><dd><%= cp.point1 %></dd></dl>
-         <% end %> 
+         <div style="margin-top : 10px">
+           <% @comparisons.each do |cp| %>
+             <dl class="dl-horizontal"><dt><%= cp.comparison %></dt><dd><%= cp.point1 %></dd></dl>
+           <% end %> 
+         </div>
        </div>
        <div class="col-xs-12 col-md-4 grid_black_mid shadow_seven">
-         <% @comparisons.each do |cp| %>
-           <dl class="dl-horizontal"><dt><%= cp.comparison %></dt><dd><%= cp.point2 %></dd></dl>
-         <% end %> 
+         <div style="margin-top : 10px">
+           <% @comparisons.each do |cp| %>
+             <dl class="dl-horizontal"><dt><%= cp.comparison %></dt><dd><%= cp.point2 %></dd></dl>
+           <% end %>
+         </div> 
        </div>
        <div class="col-xs-12 col-md-4 grid_black shadow_lawson">
-         <% @comparisons.each do |cp| %>
-           <dl class="dl-horizontal"><dt><%= cp.comparison %></dt><dd><%= cp.point3 %></dd></dl>
-         <% end %> 
+         <div style="margin-top : 10px">
+           <% @comparisons.each do |cp| %>
+             <dl class="dl-horizontal"><dt><%= cp.comparison %></dt><dd><%= cp.point3 %></dd></dl>
+           <% end %>
+         </div> 
        </div>
 
 <!-- オリジナル比較表終了 -->


### PR DESCRIPTION
#76 

作業中ですがpushします。
このブランチに対して変更加えてもらってOKです。

### 動作確認
* [私のheroku](https://intense-atoll-52414.herokuapp.com/)
* [comparisonの追加](https://intense-atoll-52414.herokuapp.com/comparisons)

### DONE
* DBのcomparisonsを全件読み込んで比較表に表示

### 残
- [x] 全件表示ではなく検索条件に従ったデータを表示するようにする
- [x] レイアウト調整
- [ ] 強調表示の追加
- [ ] ソースのリファクタリング
  - [ ] 上手くループ処理が書けなくて3社分ループしちゃってる
  - [ ] htmlタグ部分をhelper使ってスッキリさせたい（全体的に見直しになっちゃうかも）

※ユーザーの表示も結局やれてません…
