### PR TITLE
商品詳細から良い悪いの投稿が行えるようにする

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -54,7 +54,7 @@ body{
       width: 100%;
     }
     div.product div.spec{
-      height:142px;
+      height:160px;
     }
     div.product div.spec dl{
       margin-left:200px;

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -56,9 +56,9 @@ class ItemsController < ApplicationController
     end
     respond_to do |format|
       if @item.update(good:@item.good,bad:@item.bad)
-        format.html { render :view , notice: '貴方の評価を投稿しました!' }
+        format.html { redirect_to @item , notice: '貴方の評価を投稿しました!' }
       else
-        format.html { render :view , error: '投稿に失敗しました' } 
+        format.html { redirect_to @item , error: '投稿に失敗しました' } 
       end
     end
   end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -37,10 +37,29 @@ class ItemsController < ApplicationController
              @item.category=product.category
              @item.price=product.price
              @item.item=product.item
+             @item.good=0
+             @item.bad=0
              @item.save
            end
          }
       }
+    end
+  end
+
+  def vote
+    id = params[:item][:id]
+    @item = Item.find(id)
+    if params[:good] 
+      @item.good = @item.good+1
+    else
+      @item.bad = @item.bad+1
+    end
+    respond_to do |format|
+      if @item.update(good:@item.good,bad:@item.bad)
+        format.html { render :view , notice: '貴方の評価を投稿しました!' }
+      else
+        format.html { render :view , error: '投稿に失敗しました' } 
+      end
     end
   end
 

--- a/app/helpers/items_helper.rb
+++ b/app/helpers/items_helper.rb
@@ -7,6 +7,10 @@ module ItemsHelper
          concat (content_tag(:dl) do
             concat content_tag(:dt,"税込価格")
             concat content_tag(:dd,item.price.to_s + "円")
+            concat content_tag(:dt,"☆good")
+            concat content_tag(:dd,item.good)
+            concat content_tag(:dt,"★bad")
+            concat content_tag(:dd,item.bad)
          end)
        end)
      end

--- a/app/helpers/items_helper.rb
+++ b/app/helpers/items_helper.rb
@@ -1,18 +1,23 @@
 module ItemsHelper
   def print_item(item)
-     content_tag(:div, :class => 'product', :id => 'item_'+item.id.to_s) do
-       concat content_tag(:p,item.shop + '  ' + item.name,:class => 'p_name')
-       concat (content_tag(:div, :class => 'spec') do
-         concat image_tag('/images/default01.jpg', :width => '200',:style => 'float :left')
-         concat (content_tag(:dl) do
-            concat content_tag(:dt,"税込価格")
-            concat content_tag(:dd,item.price.to_s + "円")
-            concat content_tag(:dt,"☆good")
-            concat content_tag(:dd,item.good)
-            concat content_tag(:dt,"★bad")
-            concat content_tag(:dd,item.bad)
+     form_tag("/items/vote", method: "post") do
+       content_tag(:div, :class => "product", :id => "item_"+item.id.to_s) do
+         concat content_tag(:p,item.shop + "  " + item.name,:class => "p_name")
+         concat (content_tag(:div, :class => "spec") do
+           concat image_tag("/images/default01.jpg", :width => "200",:style => "float :left")
+           concat (content_tag(:dl) do
+             concat content_tag(:dt,"税込価格")
+             concat content_tag(:dd,item.price.to_s + "円")
+             concat content_tag(:dt,"☆good")
+             concat content_tag(:dd,item.good)
+             concat content_tag(:dt,"★bad")
+             concat content_tag(:dd,item.bad)
+           end)
+           concat hidden_field(:item,:id,value:item.id)
+           concat submit_tag("GOOD",:name =>"good")
+           concat submit_tag("BAD",:name =>"bad")
          end)
-       end)
+       end
      end
    end
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -1,39 +1,12 @@
 <p id="notice"><%= notice %></p>
+<% if !@item.blank? %>
+  <%= print_item(@item) %>
+  <%= link_to '商品一覧に戻る', '/show/'+@item.category %>
+<% end %>
+<% if @item.blank? %>
+  <p class="not_found">選択した商品が見つかりませんでした</p>
+<%= link_to 'トップに戻る', '/' %>
+<% end %>
 
-<p>
-  <strong>Shop:</strong>
-  <%= @item.shop %>
-</p>
 
-<p>
-  <strong>Category:</strong>
-  <%= @item.category %>
-</p>
 
-<p>
-  <strong>Item:</strong>
-  <%= @item.item %>
-</p>
-
-<p>
-  <strong>Name:</strong>
-  <%= @item.name %>
-</p>
-
-<p>
-  <strong>Price:</strong>
-  <%= @item.price %>
-</p>
-
-<p>
-  <strong>Good:</strong>
-  <%= @item.good %>
-</p>
-
-<p>
-  <strong>Bad:</strong>
-  <%= @item.bad %>
-</p>
-
-<%= link_to 'Edit', edit_item_path(@item) %> |
-<%= link_to 'Back', items_path %>

--- a/app/views/items/view.html.erb
+++ b/app/views/items/view.html.erb
@@ -1,4 +1,4 @@
-
+<p id="notice"><%= notice %></p>
 <% if !@item.blank? %>
   <%= print_item(@item) %>
   <%= link_to '商品一覧に戻る', '/show/'+@item.category %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,7 @@ Rails.application.routes.draw do
   # 商品詳細の処理
    resources :items
    get 'items/view/:name' => 'items#view'
+   post 'items/vote' => 'items#vote'
   # Example of regular route:
   #   get 'products/:id' => 'catalog#view'
 


### PR DESCRIPTION
#100 

【概要】
商品詳細画面から商品に対する良い、悪いの投稿が出来るようにする。

【作業事項】
- [x] 詳細画面に良い悪いの項目を追加する
- [x] GoodとBadの投稿ボタンを設置する
- [x] 投稿が出来るようにコントローラーを組む
- [x] 投稿後、投稿結果が反映されたことが分かるように元の詳細画面を表示する

【スクリーンショット】
変更前
![default](https://cloud.githubusercontent.com/assets/3953851/20399022/d6426fa0-ad32-11e6-8a01-356c411ae4d1.png)
変更後更新完了画面
![default](https://cloud.githubusercontent.com/assets/3953851/20399024/d8442bf4-ad32-11e6-901f-9df860c978ec.png)

【テストサイト】
https://obscure-chamber-54504.herokuapp.com/items

