### PR TITLE
「migrateコマンドにresetを追加」の取り消し

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ deploy:
   on:
     repo: IshidaHIRO/SDD3
   run:
-    - "rake db:migrate:reset"
+    - "rake db:migrate"
     - restart
     - "rake cleanup"
 


### PR DESCRIPTION
#106 の取り消しPRを上げておきます。
db:migrate:resetがpermissionでエラーとなる為です。