### PR TITLE
画像フォルダパスをItemにカラム追加

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -120,6 +120,6 @@ class ItemsController < ApplicationController
 
     # Never trust parameters from the scary internet, only allow the white list through.
     def item_params
-      params.require(:item).permit(:shop, :category, :item, :name, :price, :good, :bad)
+      params.require(:item).permit(:shop, :category, :item, :name, :price, :good, :bad, :image)
     end
 end

--- a/app/views/items/_form.html.erb
+++ b/app/views/items/_form.html.erb
@@ -39,6 +39,10 @@
     <%= f.label :bad %><br>
     <%= f.number_field :bad %>
   </div>
+  <div class="field">
+    <%= f.label :image %><br>
+    <%= f.text_field :image %>
+  </div>
   <div class="actions">
     <%= f.submit %>
   </div>

--- a/app/views/items/_item.json.jbuilder
+++ b/app/views/items/_item.json.jbuilder
@@ -1,2 +1,2 @@
-json.extract! item, :id, :shop, :category, :item, :name, :price, :good, :bad, :created_at, :updated_at
+json.extract! item, :id, :shop, :category, :item, :name, :price, :good, :bad, :image, :created_at, :updated_at
 json.url item_url(item, format: :json)

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -12,6 +12,7 @@
       <th>Price</th>
       <th>Good</th>
       <th>Bad</th>
+      <th>Image</th>
       <th colspan="3"></th>
     </tr>
   </thead>
@@ -26,6 +27,7 @@
         <td><%= item.price %></td>
         <td><%= item.good %></td>
         <td><%= item.bad %></td>
+        <td><%= item.image %></td>
         <td><%= link_to 'Show', item %></td>
         <td><%= link_to 'Edit', edit_item_path(item) %></td>
         <td><%= link_to 'Destroy', item, method: :delete, data: { confirm: 'Are you sure?' } %></td>

--- a/db/migrate/20161119074947_add_image_to_items.rb
+++ b/db/migrate/20161119074947_add_image_to_items.rb
@@ -1,0 +1,5 @@
+class AddImageToItems < ActiveRecord::Migration
+  def change
+    add_column :items, :image, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161113121309) do
+ActiveRecord::Schema.define(version: 20161119074947) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -26,6 +26,7 @@ ActiveRecord::Schema.define(version: 20161113121309) do
     t.integer  "bad"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string   "image"
   end
 
 end

--- a/test/controllers/items_controller_test.rb
+++ b/test/controllers/items_controller_test.rb
@@ -30,7 +30,7 @@ class ItemsControllerTest < ActionController::TestCase
 
   test "should create item" do
     assert_difference('Item.count') do
-      post :create, item: { bad: @item.bad, category: @item.category, good: @item.good, item: @item.item, name: @item.name, price: @item.price, shop: @item.shop }
+      post :create, item: { bad: @item.bad, category: @item.category, good: @item.good, image: @item.image, item: @item.item, name: @item.name, price: @item.price, shop: @item.shop }
     end
 
     assert_redirected_to item_path(assigns(:item))
@@ -47,7 +47,7 @@ class ItemsControllerTest < ActionController::TestCase
   end
 
   test "should update item" do
-    patch :update, id: @item, item: { bad: @item.bad, category: @item.category, good: @item.good, item: @item.item, name: @item.name, price: @item.price, shop: @item.shop }
+    patch :update, id: @item, item: { bad: @item.bad, category: @item.category, good: @item.good, image: @item.image, item: @item.item, name: @item.name, price: @item.price, shop: @item.shop }
     assert_redirected_to item_path(assigns(:item))
   end
 


### PR DESCRIPTION
#116 

[私のherokuのメンテ画面](https://intense-atoll-52414.herokuapp.com/items)

やったこと
* migrationファイルの生成「rails generate migration」
　対象：20161119074947_add_image_to_items.rb, schema.rb
* それに合わせてメンテ画面側の修正は手作業で実施しました。
　対象：上記以外のファイル