### PR TITLE
商品一覧を評判のランキング表示とする

### DIFF
--- a/app/assets/stylesheets/welcome.scss
+++ b/app/assets/stylesheets/welcome.scss
@@ -1,13 +1,13 @@
 // Place all the styles related to the welcome controller here.
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: http://sass-lang.com/
-#rank1 span.rank{
+.rank1 span.rank{
   font-size: 3em;
 }
-#rank2 span.rank{
+.rank2 span.rank{
   font-size: 2.5em;
 }
-#rank3 span.rank{
+.rank3 span.rank{
   font-size: 2em;
 }
 span.rank{

--- a/app/assets/stylesheets/welcome.scss
+++ b/app/assets/stylesheets/welcome.scss
@@ -14,3 +14,7 @@ span.rank{
   font-size:1.5em;
   margin-right:10px;
 }
+span.shop{
+  font-size: 2em;
+  margin-right: 10px;
+}

--- a/app/assets/stylesheets/welcome.scss
+++ b/app/assets/stylesheets/welcome.scss
@@ -1,3 +1,16 @@
 // Place all the styles related to the welcome controller here.
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: http://sass-lang.com/
+#rank1 span.rank{
+  font-size: 3em;
+}
+#rank2 span.rank{
+  font-size: 2.5em;
+}
+#rank3 span.rank{
+  font-size: 2em;
+}
+span.rank{
+  font-size:1.5em;
+  margin-right:10px;
+}

--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -6,7 +6,7 @@ class WelcomeController < ApplicationController
       @item = "惣菜"
     end
 
-    @product = Item.where(category: @item)
+    @product = Item.where(category: @item).order('(good + bad) DESC')
 
   end
 end

--- a/app/helpers/welcome_helper.rb
+++ b/app/helpers/welcome_helper.rb
@@ -1,8 +1,11 @@
 module WelcomeHelper
-  def print_product(target)
+  def print_product(target,index)
      link = '/items/view/'+target.name+'?shop='+target.shop
-     content_tag(:div, :class => 'product', :id => 'accordion'+target.id.to_s) do
-       concat content_tag(:a, target.shop+"  "+target.name,:class => 'p_name', :href => link) 
+     content_tag(:div, :class => 'product', :id => target.id.to_s) do
+       concat (content_tag(:span,:id => 'rank'+index) do
+         concat content_tag(:span,index+"位",:class => 'rank')
+         concat content_tag(:a, target.shop+"  "+target.name,:class => 'p_name', :href => link) 
+       end)
        concat (content_tag(:div, :class => 'spec', :id => 'collapseOne'+target.shop) do 
 	 concat content_tag(:a,image_tag('/images/default01.jpg', :width => '200',:style => 'float :left'),:href => link)
          concat (content_tag(:dl) do

--- a/app/helpers/welcome_helper.rb
+++ b/app/helpers/welcome_helper.rb
@@ -4,7 +4,8 @@ module WelcomeHelper
      content_tag(:div, :class => 'product', :id => target.id.to_s) do
        concat (content_tag(:span,:id => 'rank'+index) do
          concat content_tag(:span,index+"位",:class => 'rank')
-         concat content_tag(:a, target.shop+"  "+target.name,:class => 'p_name', :href => link) 
+         concat content_tag(:span,target.shop,:class => 'shop')
+         concat content_tag(:a, target.name,:class => 'p_name', :href => link) 
        end)
        concat (content_tag(:div, :class => 'spec', :id => 'collapseOne'+target.shop) do 
 	 concat content_tag(:a,image_tag('/images/default01.jpg', :width => '200',:style => 'float :left'),:href => link)

--- a/app/helpers/welcome_helper.rb
+++ b/app/helpers/welcome_helper.rb
@@ -2,7 +2,7 @@ module WelcomeHelper
   def print_product(target,index)
      link = '/items/view/'+target.name+'?shop='+target.shop
      content_tag(:div, :class => 'product', :id => target.id.to_s) do
-       concat (content_tag(:span,:id => 'rank'+index) do
+       concat (content_tag(:span,:class => 'rank'+index) do
          concat content_tag(:span,index+"位",:class => 'rank')
          concat content_tag(:span,target.shop,:class => 'shop')
          concat content_tag(:a, target.name,:class => 'p_name', :href => link) 

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -1,6 +1,6 @@
 <% 
   rank_adustor=0
-  before_reputation=0 
+  before_reputation=-1 
 %>
 <% @product.each_with_index do |p,index| %>
   <% 

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -1,5 +1,17 @@
+<% 
+  rank_adustor=0
+  before_reputation=0 
+%>
 <% @product.each_with_index do |p,index| %>
-  <%= print_product(p,(index+1).to_s) %>
+  <% 
+    if before_reputation == (p.good + p.bad)
+      rank_adustor = rank_adustor+1
+    else 
+      rank_adustor = 0
+    end
+  %>
+  <%= print_product(p,(index+1-rank_adustor).to_s) %>
+  <% before_reputation = p.good+p.bad %>
 <% end %>
 <% if @product.blank? %>
   <p class="not_found">選択した商品が見つかりませんでした</p>

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -1,5 +1,5 @@
-<% @product.each do |p| %>
-  <%= print_product(p) %>
+<% @product.each_with_index do |p,index| %>
+  <%= print_product(p,(index+1).to_s) %>
 <% end %>
 <% if @product.blank? %>
   <p class="not_found">選択した商品が見つかりませんでした</p>

--- a/test/controllers/welcome_controller_test.rb
+++ b/test/controllers/welcome_controller_test.rb
@@ -2,62 +2,95 @@ require 'test_helper'
 
 class WelcomeControllerTest < ActionController::TestCase
 
+  def add_item(shop,category,item,name,price,good,bad)
+    item = Item.new
+    item.shop=shop
+    item.category=category
+    item.name=name
+    item.price=price
+    item.good=good
+    item.bad=bad
+    item.save
+  end
+
   def setup
     items = Item.all
     items.each {|item| 
       item.destroy
     }
-    item_list =[]
-    item_list.push Product_dto.new(1,"ファミマ","惣菜","国産鶏のサラダチキン",239)
-    item_list.push Product_dto.new(14,"セブン","おにぎり","紀州南高梅",110)
-    item_list.push Product_dto.new(29,"ローソン","スイーツ","チョコチップスティックパン",100)
-    item_list.push Product_dto.new(30,"ファミマ","ドリンク","プレーンヨーグルトドリンク",nil)
-   
-    item_list.each{|product| 
-      item = Item.new
-      item.shop=product.shop
-      item.name=product.name
-      item.category=product.category
-      item.price=product.price
-      item.item=product.item
-      item.save 
-    }
   end  
 
   
   test "Indexの表示" do
+    # 惣菜のみが表示される
+    self.add_item('ファミマ','惣菜','惣菜','国産鶏のサラダチキン',239,0,0)
+    self.add_item('セブン','惣菜','惣菜','サラダチキン',198,0,0)
+    self.add_item('ローソン','おにぎり','おにぎり','シーチキンマヨネーズ',110,0,0)
     get :index
     assert_response :success
-    assert_select "a.p_name" 
+    assert_select "a.p_name",2
   end
+
   test "惣菜の表示" do 
+    # 惣菜のみが表示される
+    add_item('ファミマ','惣菜','惣菜','国産鶏のサラダチキン',239,0,0)
+    add_item('セブン','惣菜','惣菜','サラダチキン',198,0,0)
+    add_item('ローソン','おにぎり','おにぎり','シーチキンマヨネーズ',110,0,0)
     get :index,{"item"=>"惣菜"}
-    assert_response :success
-    assert_select "a.p_name"  
+    assert_response :success 
+    assert_select "a.p_name",2
   end 
+
   test "おにぎりの表示" do
+    # おにぎりのみが表示される
+    add_item('ファミマ','惣菜','惣菜','国産鶏のサラダチキン',239,0,0)
+    add_item('セブン','おにぎり','おにぎり','紀州南高梅',198,0,0)
+    add_item('ローソン','おにぎり','おにぎり','シーチキンマヨネーズ',110,0,0)
     get :index,{"item"=>"おにぎり"}
     assert_response :success 
-    assert_select "a.p_name" 
+    assert_select "a.p_name",2 
   end 
+
   test "スイーツの表示" do
+    #スイーツのみ表示される
+    add_item('ファミマ','スイーツ','スイーツ','プリン',239,0,0)
+    add_item('セブン','ドリンク','ドリンク','ドリンク2',198,0,0)
+    add_item('ローソン','スイーツ','スイーツ','チョコチップスナック',110,0,0)
     get :index,{"item"=>"スイーツ"}
     assert_response :success 
-    assert_select "a.p_name" 
+    assert_select "a.p_name",2 
   end 
+
   test "飲むヨーグルト（プレーン）の表示" do 
+    #ドリンクのみ表示される
+    add_item('ファミマ','ドリンク','ドリンク','ドリンク1',239,0,0)
+    add_item('セブン','ドリンク','ドリンク','ドリンク2',198,0,0)
+    add_item('ローソン','おにぎり','おにぎり','シーチキンマヨネーズ',110,0,0)
     get :index,{"item"=>"ドリンク"}
     assert_response :success 
-    assert_select "a.p_name" 
+    assert_select "a.p_name",2 
   end 
+
   test "NotFoundの表示" do 
+    #なにも表示されない
+    add_item('ファミマ','惣菜','惣菜','国産鶏のサラダチキン',239,0,0)
+    add_item('セブン','惣菜','惣菜','サラダチキン',198,0,0)
+    add_item('ローソン','おにぎり','おにぎり','シーチキンマヨネーズ',110,0,0)
     get :index,{"item"=>"適当な商品"}
     assert_response :success 
     assert_select ".not_found",1 
-
-  end 
-  
- 
-
-  
+  end
+    
+  test "商品表示順の確認" do
+    #惣菜のみが表示される
+    #惣菜2、惣菜3、惣菜1の順に表示される
+    item1 = add_item('ファミマ','惣菜','惣菜','惣菜1',239,5,4)
+    item2 = add_item('セブン','惣菜','惣菜','惣菜2',198,0,20)
+    item3 = add_item('ローソン','惣菜','惣菜','惣菜3',110,10,0)  
+    get :index,{"item"=>"惣菜"}
+    assert_response :success 
+    assert_select "#rank1 .p_name","惣菜2"
+    assert_select "#rank2 .p_name","惣菜3"
+    assert_select "#rank3 .p_name","惣菜1"
+  end
 end

--- a/test/controllers/welcome_controller_test.rb
+++ b/test/controllers/welcome_controller_test.rb
@@ -89,8 +89,19 @@ class WelcomeControllerTest < ActionController::TestCase
     item3 = add_item('ローソン','惣菜','惣菜','惣菜3',110,10,0)  
     get :index,{"item"=>"惣菜"}
     assert_response :success 
-    assert_select "#rank1 .p_name","惣菜2"
-    assert_select "#rank2 .p_name","惣菜3"
-    assert_select "#rank3 .p_name","惣菜1"
+    assert_select ".rank1 .p_name","惣菜2"
+    assert_select ".rank2 .p_name","惣菜3"
+    assert_select ".rank3 .p_name","惣菜1"
+  end
+  
+  test "商品表示順の確認(同率時)" do
+    item1 = add_item('ファミマ','惣菜','惣菜','惣菜1',239,5,4)
+    item2 = add_item('セブン','惣菜','惣菜','惣菜2',198,0,20)
+    item3 = add_item('ローソン','惣菜','惣菜','惣菜3',110,20,0)  
+    get :index,{"item"=>"惣菜"}
+    assert_response :success 
+    assert_select ".rank1 .p_name",2
+    assert_select ".rank2 .p_name",0
+    assert_select ".rank3 .p_name",1
   end
 end

--- a/test/controllers/welcome_controller_test.rb
+++ b/test/controllers/welcome_controller_test.rb
@@ -94,7 +94,7 @@ class WelcomeControllerTest < ActionController::TestCase
     assert_select ".rank3 .p_name","惣菜1"
   end
   
-  test "商品表示順の確認(同率時)" do
+  test "商品表示順の確認(同点時)" do
     item1 = add_item('ファミマ','惣菜','惣菜','惣菜1',239,5,4)
     item2 = add_item('セブン','惣菜','惣菜','惣菜2',198,0,20)
     item3 = add_item('ローソン','惣菜','惣菜','惣菜3',110,20,0)  
@@ -103,5 +103,16 @@ class WelcomeControllerTest < ActionController::TestCase
     assert_select ".rank1 .p_name",2
     assert_select ".rank2 .p_name",0
     assert_select ".rank3 .p_name",1
+  end
+  
+  test "商品表示順の確認(全て同点時)" do
+    item1 = add_item('ファミマ','惣菜','惣菜','惣菜1',239,0,0)
+    item2 = add_item('セブン','惣菜','惣菜','惣菜2',198,0,0)
+    item3 = add_item('ローソン','惣菜','惣菜','惣菜3',110,0,0)  
+    get :index,{"item"=>"惣菜"}
+    assert_response :success 
+    assert_select ".rank1 .p_name",3
+    assert_select ".rank2 .p_name",0
+    assert_select ".rank3 .p_name",0
   end
 end

--- a/test/controllers/welcome_controller_test.rb
+++ b/test/controllers/welcome_controller_test.rb
@@ -2,10 +2,11 @@ require 'test_helper'
 
 class WelcomeControllerTest < ActionController::TestCase
 
-  def add_item(shop,category,item,name,price,good,bad)
+  def add_item(shop,category,name,price,good,bad)
     item = Item.new
     item.shop=shop
     item.category=category
+    item.item=category
     item.name=name
     item.price=price
     item.good=good
@@ -23,9 +24,9 @@ class WelcomeControllerTest < ActionController::TestCase
   
   test "Indexの表示" do
     # 惣菜のみが表示される
-    self.add_item('ファミマ','惣菜','惣菜','国産鶏のサラダチキン',239,0,0)
-    self.add_item('セブン','惣菜','惣菜','サラダチキン',198,0,0)
-    self.add_item('ローソン','おにぎり','おにぎり','シーチキンマヨネーズ',110,0,0)
+    self.add_item('ファミマ','惣菜','国産鶏のサラダチキン',239,0,0)
+    self.add_item('セブン','惣菜','サラダチキン',198,0,0)
+    self.add_item('ローソン','おにぎり','シーチキンマヨネーズ',110,0,0)
     get :index
     assert_response :success
     assert_select "a.p_name",2
@@ -33,9 +34,9 @@ class WelcomeControllerTest < ActionController::TestCase
 
   test "惣菜の表示" do 
     # 惣菜のみが表示される
-    add_item('ファミマ','惣菜','惣菜','国産鶏のサラダチキン',239,0,0)
-    add_item('セブン','惣菜','惣菜','サラダチキン',198,0,0)
-    add_item('ローソン','おにぎり','おにぎり','シーチキンマヨネーズ',110,0,0)
+    add_item('ファミマ','惣菜','国産鶏のサラダチキン',239,0,0)
+    add_item('セブン','惣菜','サラダチキン',198,0,0)
+    add_item('ローソン','おにぎり','シーチキンマヨネーズ',110,0,0)
     get :index,{"item"=>"惣菜"}
     assert_response :success 
     assert_select "a.p_name",2
@@ -43,9 +44,9 @@ class WelcomeControllerTest < ActionController::TestCase
 
   test "おにぎりの表示" do
     # おにぎりのみが表示される
-    add_item('ファミマ','惣菜','惣菜','国産鶏のサラダチキン',239,0,0)
-    add_item('セブン','おにぎり','おにぎり','紀州南高梅',198,0,0)
-    add_item('ローソン','おにぎり','おにぎり','シーチキンマヨネーズ',110,0,0)
+    add_item('ファミマ','惣菜','国産鶏のサラダチキン',239,0,0)
+    add_item('セブン','おにぎり','紀州南高梅',198,0,0)
+    add_item('ローソン','おにぎり','シーチキンマヨネーズ',110,0,0)
     get :index,{"item"=>"おにぎり"}
     assert_response :success 
     assert_select "a.p_name",2 
@@ -53,9 +54,9 @@ class WelcomeControllerTest < ActionController::TestCase
 
   test "スイーツの表示" do
     #スイーツのみ表示される
-    add_item('ファミマ','スイーツ','スイーツ','プリン',239,0,0)
-    add_item('セブン','ドリンク','ドリンク','ドリンク2',198,0,0)
-    add_item('ローソン','スイーツ','スイーツ','チョコチップスナック',110,0,0)
+    add_item('ファミマ','スイーツ','プリン',239,0,0)
+    add_item('セブン','ドリンク','ドリンク2',198,0,0)
+    add_item('ローソン','スイーツ','チョコチップスナック',110,0,0)
     get :index,{"item"=>"スイーツ"}
     assert_response :success 
     assert_select "a.p_name",2 
@@ -63,9 +64,9 @@ class WelcomeControllerTest < ActionController::TestCase
 
   test "飲むヨーグルト（プレーン）の表示" do 
     #ドリンクのみ表示される
-    add_item('ファミマ','ドリンク','ドリンク','ドリンク1',239,0,0)
-    add_item('セブン','ドリンク','ドリンク','ドリンク2',198,0,0)
-    add_item('ローソン','おにぎり','おにぎり','シーチキンマヨネーズ',110,0,0)
+    add_item('ファミマ','ドリンク','ドリンク1',239,0,0)
+    add_item('セブン','ドリンク','ドリンク2',198,0,0)
+    add_item('ローソン','おにぎり','シーチキンマヨネーズ',110,0,0)
     get :index,{"item"=>"ドリンク"}
     assert_response :success 
     assert_select "a.p_name",2 
@@ -73,9 +74,9 @@ class WelcomeControllerTest < ActionController::TestCase
 
   test "NotFoundの表示" do 
     #なにも表示されない
-    add_item('ファミマ','惣菜','惣菜','国産鶏のサラダチキン',239,0,0)
-    add_item('セブン','惣菜','惣菜','サラダチキン',198,0,0)
-    add_item('ローソン','おにぎり','おにぎり','シーチキンマヨネーズ',110,0,0)
+    add_item('ファミマ','惣菜','国産鶏のサラダチキン',239,0,0)
+    add_item('セブン','惣菜','サラダチキン',198,0,0)
+    add_item('ローソン','おにぎり','シーチキンマヨネーズ',110,0,0)
     get :index,{"item"=>"適当な商品"}
     assert_response :success 
     assert_select ".not_found",1 
@@ -84,9 +85,9 @@ class WelcomeControllerTest < ActionController::TestCase
   test "商品表示順の確認" do
     #惣菜のみが表示される
     #惣菜2、惣菜3、惣菜1の順に表示される
-    item1 = add_item('ファミマ','惣菜','惣菜','惣菜1',239,5,4)
-    item2 = add_item('セブン','惣菜','惣菜','惣菜2',198,0,20)
-    item3 = add_item('ローソン','惣菜','惣菜','惣菜3',110,10,0)  
+    add_item('ファミマ','惣菜','惣菜1',239,5,4)
+    add_item('セブン','惣菜','惣菜2',198,0,20)
+    add_item('ローソン','惣菜','惣菜3',110,10,0)  
     get :index,{"item"=>"惣菜"}
     assert_response :success 
     assert_select ".rank1 .p_name","惣菜2"
@@ -95,9 +96,9 @@ class WelcomeControllerTest < ActionController::TestCase
   end
   
   test "商品表示順の確認(同点時)" do
-    item1 = add_item('ファミマ','惣菜','惣菜','惣菜1',239,5,4)
-    item2 = add_item('セブン','惣菜','惣菜','惣菜2',198,0,20)
-    item3 = add_item('ローソン','惣菜','惣菜','惣菜3',110,20,0)  
+    add_item('ファミマ','惣菜','惣菜1',239,5,4)
+    add_item('セブン','惣菜','惣菜2',198,0,20)
+    add_item('ローソン','惣菜','惣菜3',110,20,0)  
     get :index,{"item"=>"惣菜"}
     assert_response :success 
     assert_select ".rank1 .p_name",2
@@ -106,9 +107,9 @@ class WelcomeControllerTest < ActionController::TestCase
   end
   
   test "商品表示順の確認(全て同点時)" do
-    item1 = add_item('ファミマ','惣菜','惣菜','惣菜1',239,0,0)
-    item2 = add_item('セブン','惣菜','惣菜','惣菜2',198,0,0)
-    item3 = add_item('ローソン','惣菜','惣菜','惣菜3',110,0,0)  
+    add_item('ファミマ','惣菜','惣菜1',239,0,0)
+    add_item('セブン','惣菜','惣菜2',198,0,0)
+    add_item('ローソン','惣菜','惣菜3',110,0,0)  
     get :index,{"item"=>"惣菜"}
     assert_response :success 
     assert_select ".rank1 .p_name",3


### PR DESCRIPTION
#110 #124 #118 

【概要】
商品一覧を評判のランキング表示とする。

【作業事項】
- [x] 商品一覧の表示順をGood+Badの大きい順とする
- [x] ランキングの1位、2位、3位・・・が一覧表に表示されるようにする
- [x] 評判の値が同じ場合、ランキングは同一とする

【スクリーンショット】
変更前
![default](https://cloud.githubusercontent.com/assets/3953851/20460614/7a7581da-af2b-11e6-9083-186372969e9d.png)
ランキング表示
![default](https://cloud.githubusercontent.com/assets/3953851/20460615/7e34b2c8-af2b-11e6-9bea-1bc33578de6c.png)
同率がある場合
![default](https://cloud.githubusercontent.com/assets/3953851/20460616/854e7b7a-af2b-11e6-9b3e-d7c93e41d222.png)

【テストサイト】
https://obscure-chamber-54504.herokuapp.com/
