### PR TITLE
#132商品画像の表示に画像データがない場合の処理を追加

### DIFF
--- a/app/helpers/items_helper.rb
+++ b/app/helpers/items_helper.rb
@@ -4,7 +4,7 @@ module ItemsHelper
        content_tag(:div, :class => "product clearfix", :id => "item_"+item.id.to_s,) do
          concat content_tag(:p,item.shop + "  " + item.name,:class => "p_name")
          concat (content_tag(:div, :class => "spec") do
-	   if item.image.nil?
+	   if item.image.blank?
              concat image_tag("/images/default01.jpg", :width => "200",:style => "float :left")
            else 
              concat content_tag(:a,image_tag('/images/'+item.image, :width => '150',:style => "float :left"),:href => link)

--- a/app/helpers/items_helper.rb
+++ b/app/helpers/items_helper.rb
@@ -4,8 +4,11 @@ module ItemsHelper
        content_tag(:div, :class => "product clearfix", :id => "item_"+item.id.to_s,) do
          concat content_tag(:p,item.shop + "  " + item.name,:class => "p_name")
          concat (content_tag(:div, :class => "spec") do
-##           concat image_tag("/images/default01.jpg", :width => "200",:style => "float :left")
-           concat image_tag('/images/'+item.image, :width => "150",:style => "float :left")
+	   if item.image.nil?
+             concat image_tag("/images/default01.jpg", :width => "200",:style => "float :left")
+           else 
+             concat content_tag(:a,image_tag('/images/'+item.image, :width => '150',:style => "float :left"),:href => link)
+           end  
            concat (content_tag(:dl) do
              concat content_tag(:dt,"税込価格", :style => "float :left")
              concat content_tag(:dd,item.price.to_s + "円", :style => "margin-left :80px")

--- a/app/helpers/welcome_helper.rb
+++ b/app/helpers/welcome_helper.rb
@@ -4,7 +4,7 @@ module WelcomeHelper
      content_tag(:div, :class => 'product clearfix', :id => 'accordion'+target.id.to_s) do
        concat content_tag(:a, target.shop+"  "+target.name,:class => 'p_name', :href => link) 
        concat (content_tag(:div, :class => 'spec', :id => 'collapseOne'+target.shop) do 
-	 if target.image.nil?
+	 if target.image.blank?
            concat image_tag("/images/default01.jpg", :width => "200",:style => "float :left")
          else 
            concat content_tag(:a,image_tag('/images/'+target.image, :width => '150',:style => "float :left"),:href => link)

--- a/app/helpers/welcome_helper.rb
+++ b/app/helpers/welcome_helper.rb
@@ -4,7 +4,11 @@ module WelcomeHelper
      content_tag(:div, :class => 'product clearfix', :id => 'accordion'+target.id.to_s) do
        concat content_tag(:a, target.shop+"  "+target.name,:class => 'p_name', :href => link) 
        concat (content_tag(:div, :class => 'spec', :id => 'collapseOne'+target.shop) do 
-	 concat content_tag(:a,image_tag('/images/'+target.image, :width => '150',:style => "float :left"),:href => link)
+	 if target.image.nil?
+           concat image_tag("/images/default01.jpg", :width => "200",:style => "float :left")
+         else 
+           concat content_tag(:a,image_tag('/images/'+target.image, :width => '150',:style => "float :left"),:href => link)
+         end
          concat (content_tag(:dl) do
 	    concat content_tag(:dt,"税込価格", :style => "float :left")
 	    concat content_tag(:dd,target.price.to_s + "円", :style => "margin-left :80px")

--- a/test/controllers/welcome_controller_test.rb
+++ b/test/controllers/welcome_controller_test.rb
@@ -20,6 +20,8 @@ class WelcomeControllerTest < ActionController::TestCase
       item.category=product.category
       item.price=product.price
       item.item=product.item
+      item.good=0
+      item.bad=0
       item.save 
     }
   end  


### PR DESCRIPTION
#132 

【修正箇所】
・画像のカラムが登録されていないデータは標準画像を表示するように修正
・テストデータがgood/badがない頃のものでnilで落ちていたので修正。
