### PR TITLE
スマホ用レイアウト調整(商品詳細画面)

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -55,7 +55,7 @@ body{
       width: 100%;
     }
     div.product div.spec{
-      height:160px;
+      min-height:160px;
     }
     div.product div.spec dl{
       margin-left:160px;

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -48,7 +48,8 @@ body{
     }
     .p_name{
       font-size: 2em;
-      color: #800000;      
+      color: #800000;
+      line-height:1em;      
     }
     .dd-width{
       width: 100%;

--- a/app/assets/stylesheets/items.scss
+++ b/app/assets/stylesheets/items.scss
@@ -42,6 +42,6 @@ div.footer{
 }
 div.spec img{
   width:150px;
-  height:156px;
+  min-height:156px;
   float:left;
 }

--- a/app/assets/stylesheets/items.scss
+++ b/app/assets/stylesheets/items.scss
@@ -40,3 +40,8 @@ div.spec input[type="submit"].btn-lg{
 div.footer{
   margin:20px;
 }
+div.spec img{
+  width:150px;
+  height:156px;
+  float:left;
+}

--- a/app/assets/stylesheets/items.scss
+++ b/app/assets/stylesheets/items.scss
@@ -25,6 +25,11 @@ div.comment dl dd{
 div.comment dl dd input[type="text"]{
   width:200px;
 }
+@media all and (max-width: 480px){
+  div.comment dl dd input[type="text"]#item_review_handlename{
+    width:100%;
+  }
+}
 div.comment dl dd textarea{
   width:100%;
 }

--- a/app/assets/stylesheets/items.scss
+++ b/app/assets/stylesheets/items.scss
@@ -28,3 +28,7 @@ div.comment dl dd input[type="text"]{
 div.comment dl dd textarea{
   width:100%;
 }
+div.spec input[type="submit"].btn-lg{
+  margin-left:20px;
+  margin-top:10px;
+}

--- a/app/assets/stylesheets/items.scss
+++ b/app/assets/stylesheets/items.scss
@@ -37,3 +37,6 @@ div.spec input[type="submit"].btn-lg{
   margin-left:20px;
   margin-top:10px;
 }
+div.footer{
+  margin:20px;
+}

--- a/app/helpers/items_helper.rb
+++ b/app/helpers/items_helper.rb
@@ -9,19 +9,19 @@ module ItemsHelper
            else
              concat image_tag('/images/'+item.image, :width => "150",:style => "float :left")
            end
-           concat (content_tag(:dl) do
-             concat content_tag(:dt,"税込価格")
-             concat content_tag(:dd,item.price.to_s + "円")
-             concat content_tag(:dt,"話題度")
-             concat content_tag(:dd,item.good + item.bad)
-             concat content_tag(:dt,"good/bad")
-             concat content_tag(:dd,item.good.to_s+"/"+item.bad.to_s)
-           end)
-             concat (content_tag(:div, :style => "margin-left :160px") do 
-               concat hidden_field(:item,:id,value:item.id)
-               concat submit_tag("GOOD",:name =>"item[good]",:class => "btn btn-lg btn-primary")
-               concat submit_tag("BAD",:name =>"item[bad]",:class => "btn btn-lg btn-danger",:style =>"margin-left:20px")
+           concat (content_tag(:div) do
+             concat (content_tag(:dl) do
+               concat content_tag(:dt,"税込価格")
+               concat content_tag(:dd,item.price.to_s + "円")
+               concat content_tag(:dt,"話題度")
+               concat content_tag(:dd,item.good + item.bad)
+               concat content_tag(:dt,"good/bad")
+               concat content_tag(:dd,item.good.to_s+"/"+item.bad.to_s)
              end)
+             concat hidden_field(:item,:id,value:item.id)
+             concat submit_tag("GOOD",:name =>"item[good]",:class => "btn btn-lg btn-primary")
+             concat submit_tag("BAD",:name =>"item[bad]",:class => "btn btn-lg btn-danger")
+           end)
          end)
        end
      end

--- a/app/helpers/items_helper.rb
+++ b/app/helpers/items_helper.rb
@@ -1,6 +1,5 @@
 module ItemsHelper
   def print_item(item)
-     link = "/show/" + item.category
      form_tag("/items/vote", method: "post") do
        content_tag(:div, :class => "product clearfix", :id => "item_"+item.id.to_s,) do
          concat content_tag(:p,item.shop + "  " + item.name,:class => "p_name")
@@ -19,7 +18,7 @@ module ItemsHelper
              concat content_tag(:dd,item.good.to_s+"/"+item.bad.to_s)
            end)
              concat (content_tag(:div, :style => "margin-left :160px") do 
-               concat hidden_field(:item,:id,value:item.id, :style => "margin-left :10px")
+               concat hidden_field(:item,:id,value:item.id)
                concat submit_tag("GOOD",:name =>"item[good]",:class => "btn btn-lg btn-primary")
                concat submit_tag("BAD",:name =>"item[bad]",:class => "btn btn-lg btn-danger",:style =>"margin-left:20px")
              end)

--- a/app/helpers/items_helper.rb
+++ b/app/helpers/items_helper.rb
@@ -5,9 +5,9 @@ module ItemsHelper
          concat content_tag(:p,item.shop + "  " + item.name,:class => "p_name")
          concat (content_tag(:div, :class => "spec") do
            if item.image.blank?
-             concat image_tag("/images/default01.jpg", :width => "150",:style => "float :left")
+             concat image_tag("/images/default01.jpg")
            else
-             concat image_tag('/images/'+item.image, :width => "150",:style => "float :left")
+             concat image_tag('/images/'+item.image)
            end
            concat (content_tag(:div) do
              concat (content_tag(:dl) do
@@ -26,7 +26,4 @@ module ItemsHelper
        end
      end
    end
-
-
-
 end

--- a/app/helpers/items_helper.rb
+++ b/app/helpers/items_helper.rb
@@ -8,7 +8,7 @@ module ItemsHelper
            if item.image.blank?
              concat image_tag("/images/default01.jpg", :width => "150",:style => "float :left")
            else
-             concat content_tag(:a,image_tag('/images/'+item.image, :width => "150",:style => "float :left"),:href => link)
+             concat image_tag('/images/'+item.image, :width => "150",:style => "float :left")
            end
            concat (content_tag(:dl) do
              concat content_tag(:dt,"税込価格")

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -34,9 +34,9 @@
     </table>
   <% end %>
   </div>
-  <%= link_to '商品一覧に戻る', '/show/'+@item.category %>
+  <div class="footer"><%= link_to '商品一覧に戻る', '/show/'+@item.category,:class=>'btn btn-lg btn-default' %></div>
 <% end %>
 <% if @item.blank? %>
   <p class="not_found">選択した商品が見つかりませんでした</p>
-<%= link_to 'トップに戻る', '/' %>
+  <div class="footer"><%= link_to 'トップに戻る', '/' ,:class=>'btn btn-lg btn-default' %></div>
 <% end %>


### PR DESCRIPTION
#150 

- [x] 商品名のフォントが重なっている
- [x] Good/Badのボタンがずれている
- [x] ハンドルネームの投稿欄がはみ出ている
- [x] 商品一覧に戻るが押しにくい

【スクリーンショット】
「商品名のフォントが重なっている」の修正
![default](https://cloud.githubusercontent.com/assets/3953851/20597173/8a3fe206-b285-11e6-9c7b-fcaed8f57aa3.png)
「Good/Badのボタンがずれている」の修正
![default](https://cloud.githubusercontent.com/assets/3953851/20597174/8d631174-b285-11e6-940c-c01eea7e1ab7.png)
「ハンドルネームの投稿欄がはみ出ている」の修正
![default](https://cloud.githubusercontent.com/assets/3953851/20597178/9381633a-b285-11e6-86a0-6eda29851a9d.png)
「商品一覧に戻るが押しにくい」の修正
![default](https://cloud.githubusercontent.com/assets/3953851/20597184/976bcaee-b285-11e6-96a5-5f665b70b723.png)

【テストサイト】
https://obscure-chamber-54504.herokuapp.com/