### PR TITLE
商品画像に商品詳細へのリンクを追加

### DIFF
--- a/app/helpers/welcome_helper.rb
+++ b/app/helpers/welcome_helper.rb
@@ -21,7 +21,7 @@ module WelcomeHelper
        end)
        concat (content_tag(:div, :class => 'spec', :id => 'collapseOne'+target.shop) do 
          if target.image.blank?
-           concat image_tag('/images/default01.jpg')
+	   concat content_tag(:a,image_tag('/images/default01.jpg'),:href => link)
          else
 	   concat content_tag(:a,image_tag('/images/'+target.image),:href => link)
          end


### PR DESCRIPTION
#168 #167 

【概要】
画像ありの場合は画像に商品詳細へのリンクが設定されてますが、デフォルト画像では設定されていない件について、修正しました。

【テストサイト】
https://obscure-chamber-54504.herokuapp.com/